### PR TITLE
Structs have default initialisers

### DIFF
--- a/ParserExerciseTests/ParserExerciseTests.swift
+++ b/ParserExerciseTests/ParserExerciseTests.swift
@@ -53,8 +53,7 @@ public func failWithParseError<A>(e : ParseError) -> ParseResult<A> { return .Er
 // * a parse error
 public struct Parser<A> {
     let p : Input -> ParseResult<A>
-    init(p : Input -> ParseResult<A>) { self.p = p }
-    
+
     public func parse(i : Input) -> ParseResult<A> { return self.p(i) }
 }
 public func TODO<A>() -> Parser<A> { return Parser({ i in .ErrorResult(.Failed("*** TODO ***"))}) }


### PR DESCRIPTION
Structs have default initialisers, which means this code is redundant.
